### PR TITLE
WIP : port to nextflow dsl2

### DIFF
--- a/modules/buildRecords.nf
+++ b/modules/buildRecords.nf
@@ -1,0 +1,70 @@
+process build_records {
+    stageInMode 'copy'
+    input:
+        tuple val(index), path('images/*')
+    output:
+        tuple val(index), path('*.tfrecord'), emit: ch_shards
+        tuple val(index), path('images/*', includeInputs: true), emit: ch_originals
+        tuple val(index), path('ratios.p'), emit: ch_ratios
+        path '*.txt', optional: true, emit: invalid_images
+    script:
+        """
+        #!/usr/bin/env python
+
+        import logging
+        import os
+        import pickle
+
+        import tensorflow as tf
+
+        from data_record import create_record
+
+        logger = tf.get_logger()
+        logger.propagate = False
+        logger.setLevel('INFO')
+
+        images = tf.io.gfile.glob('images/*')
+
+        count = len(images)
+        invalid = 0
+        scale_factors = {}
+
+        with tf.io.TFRecordWriter('chunk.tfrecord') as writer:
+            for i in range(count):
+                filename = os.path.basename(images[i])
+                image_data = tf.io.gfile.GFile(images[i], 'rb').read()
+                try:
+                    image = tf.io.decode_image(image_data, channels=3)
+                except tf.errors.InvalidArgumentError:
+                    logger.info("%s is either corrupted or not a supported image format" % filename)
+                    invalid += 1
+                    with open("invalid.txt", "a") as broken:
+                        broken.write(f'{filename}\\n')
+                    continue
+
+                height, width = image.shape[:2]
+                max_dimension = 602
+                ratio = 1.0
+
+                if height * width > max_dimension**2:
+                    logger.info('%s: dimensions %d x %d are too large,' % (filename, height, width))
+                    ratio = max(height,width)/max_dimension
+                    new_height = int(height/ratio)
+                    new_width = int(width/ratio)
+                    logger.info('%s: resized to %d x %d (scale factor:%f)' % (filename, new_height, new_width, ratio))
+                    image = tf.image.resize(image, size=[new_height,new_width], preserve_aspect_ratio=False, antialias=True)
+                    image_data = tf.image.encode_png(tf.cast(image, tf.uint8)).numpy()
+                    tf.io.write_file(os.path.join(f'images/{filename}'), image_data)
+
+                scale_factors[filename] = ratio
+                record = create_record(image_data=image_data,
+                                    filename=filename,
+                                    height=height,
+                                    width=width,
+                                    ratio=ratio)
+
+                writer.write(record.SerializeToString())
+
+        pickle.dump(scale_factors, open("ratios.p", "wb"))
+        """
+}

--- a/modules/drawDiagnostics.nf
+++ b/modules/drawDiagnostics.nf
@@ -1,0 +1,21 @@
+process draw_diagnostics {
+    publishDir "${params.outdir}/diagnostics", mode: 'copy',
+        saveAs: { filename ->
+                    if (filename.startsWith("mask_")) "summary/mask/$filename"
+                    else if (filename.startsWith("overlay_")) "summary/overlay/$filename"
+                    else if (filename.startsWith("crop_")) "summary/crop/$filename"
+                    else null
+                }
+    input:
+        tuple val(index), val(type), path(image)
+    output:
+        path('*.jpeg')
+
+    script:
+        def polaroid = params.polaroid ? '+polaroid' : ''
+        """
+        #!/usr/bin/env bash
+
+        montage * -background 'black' -font Ubuntu-Condensed -geometry 200x200 -set label '%t' -fill white ${polaroid} "${type}_chunk_${index}.jpeg"
+        """
+}

--- a/modules/extractTraits.nf
+++ b/modules/extractTraits.nf
@@ -1,0 +1,55 @@
+process extract_traits {
+    publishDir "${params.outdir}/diagnostics", mode: 'copy',
+        saveAs: { filename ->
+                if (filename.startsWith("mask_")) "mask/$filename"
+                else if (filename.startsWith("overlay_")) "overlay/$filename"
+                else if (filename.startsWith("crop_")) "crop/$filename"
+                else if (filename.startsWith("hull_")) "convex_hull/$filename"
+                else null
+            }
+
+    input:
+        tuple val(index), path("original_images/*"), path("raw_masks/*"), path(ratios)
+        val(labels)
+        val(ignore_label)
+
+    output:
+        path '*.csv', emit: ch_results
+        tuple val(index), val('mask'), path('mask_*'), optional: true, emit: ch_masks
+        tuple val(index), val('overlay'), path('overlay_*'), optional: true, emit: ch_overlays
+        tuple val(index), val('crop'), path('crop_*'), optional: true, emit: ch_crops
+        tuple val(index), val('hull'), path('hull_*'), optional: true, emit: ch_hull
+
+    script:
+        def scale_ratios = ratios.name != 'ratios.p' ? "None" : "pickle.load(open('ratios.p','rb'))"
+        def cmap = params.warhol ? "[[250,140,130],[119,204,98],[240,216,72],[82,128,199],[242,58,58]]" : "None"
+        """
+        #!/usr/bin/env python
+
+        import os
+        import pickle
+
+        from traits import measure_traits, draw_diagnostics, load_images
+
+        ratios = ${scale_ratios}
+        masks, originals = load_images()
+
+        for index, name in enumerate(originals.files):
+            measure_traits(masks[index],
+                        originals[index],
+                        ratios[os.path.basename(name)] if ratios is not None else 1.0,
+                        os.path.basename(name),
+                        ignore_label=${ignore_label},
+                        labels=dict(${labels}))
+            draw_diagnostics(masks[index],
+                            originals[index],
+                            os.path.basename(name),
+                            save_overlay=${params.save_overlay.toString().capitalize()},
+                            save_mask=${params.save_mask.toString().capitalize()},
+                            save_rosette=${params.save_rosette.toString().capitalize()},
+                            save_hull=${params.save_hull.toString().capitalize()},
+                            ignore_label=${ignore_label},
+                            labels=dict(${labels}),
+                            colormap=${cmap})
+        """
+}

--- a/modules/launchShiny.nf
+++ b/modules/launchShiny.nf
@@ -1,0 +1,15 @@
+process launch_shiny {
+    tag "http://${"uname".execute().text.trim() == "Darwin" ? "localhost" : "hostname -i".execute().text.trim()}:44333"
+    containerOptions { workflow.profile.contains('singularity') ? '' : '-p 44333:44333' }
+    executor 'local'
+    cache false
+
+    input:
+        path ch_resultfile
+        path app
+        env LABELS
+    script:
+        """
+        R -e "shiny::runApp('${app}', port=44333, host='0.0.0.0')"
+        """
+}

--- a/modules/runPredictions.nf
+++ b/modules/runPredictions.nf
@@ -1,0 +1,47 @@
+process run_predictions {
+    input:
+        path(model)
+        tuple val(index), path(shard)
+    output:
+        tuple val(index), path('*.png'), emit: ch_predictions
+    script:
+        """
+        #!/usr/bin/env python
+
+        import logging
+
+        import tensorflow as tf
+
+        from data_record import parse_record
+        from frozen_graph import wrap_frozen_graph
+
+        logger = tf.get_logger()
+        logger.propagate = False
+        logger.setLevel('INFO')
+
+        with tf.io.gfile.GFile('${model}', "rb") as f:
+            graph_def = tf.compat.v1.GraphDef()
+            graph_def.ParseFromString(f.read())
+
+        predict = wrap_frozen_graph(
+            graph_def,
+            inputs='ImageTensor:0',
+            outputs='SemanticPredictions:0')
+
+        dataset = (
+            tf.data.TFRecordDataset('${shard}')
+            .map(parse_record)
+            .batch(1)
+            .prefetch(1)
+            .enumerate(start=1))
+
+        size = len(list(dataset))
+
+        for index, sample in dataset:
+            filename = sample['filename'].numpy()[0].decode('utf-8')
+            logger.info("Running prediction on image %s (%d/%d)" % (filename,index,size))
+            raw_segmentation = predict(sample['original'])[0][:, :, None]
+            output = tf.image.encode_png(tf.cast(raw_segmentation, tf.uint8))
+            tf.io.write_file(filename.rsplit('.', 1)[0] + '.png',output)
+        """
+}

--- a/modules/runPredictionsDPP.nf
+++ b/modules/runPredictionsDPP.nf
@@ -1,0 +1,57 @@
+process run_predictions_DPP {
+    input:
+        path("vegetation-segmentation/*")
+        tuple val(index), path(shard)
+    output:
+        tuple val(index), path('*.png'), emit: ch_predictions
+    script:
+        """
+        #!/usr/bin/env python
+
+        import logging
+
+        import numpy as np
+        import tensorflow as tf
+        import deepplantphenomics as dpp
+
+        from cv2 import imwrite
+        from data_record import parse_record
+
+        logger = tf.get_logger()
+        logger.propagate = False
+        logger.setLevel('INFO')
+
+        pretrainedDPP = dpp.networks.vegetationSegmentationNetwork(8)
+
+        def checkpoint_override(net, checkpoint_path, num_classes):
+            if num_classes != 2:
+                net.model.set_num_segmentation_classes(num_classes)
+            net.model._add_layers_to_graph()
+            saver = tf.compat.v1.train.Saver()
+            saver.restore(net.model._session, tf.train.latest_checkpoint(checkpoint_path))
+
+        with pretrainedDPP.model._graph.as_default():
+            checkpoint_override(pretrainedDPP,'vegetation-segmentation/', 2)
+            dataset = (
+            tf.data.TFRecordDataset('${shard}')
+            .map(parse_record)
+            .batch(1)
+            .prefetch(1))
+
+            samples = tf.compat.v1.data.make_one_shot_iterator(dataset).get_next()
+
+            for i in samples:
+                img, filename = tf.cast(samples['original'],tf.float32),  samples['filename']
+                raw = pretrainedDPP.model.forward_pass(img, deterministic=True)
+                try:
+                    while True:
+                        prediction, name = pretrainedDPP.model._session.run([raw,filename])
+                        logger.info("Running prediction on image %s" % name)
+                        seg = np.interp(prediction, (prediction.min(), prediction.max()), (0, 1))
+                        mask = (np.squeeze(seg) > 0.5).astype(np.uint8)
+                        name = name[0].decode('utf-8').rsplit('.', 1)[0]
+                        imwrite(f'{name}.png', mask)
+                except tf.errors.OutOfRangeError:
+                    pass
+        """
+}


### PR DESCRIPTION
With [DSL2](https://www.nextflow.io/docs/latest/dsl2.html) likely to be promoted stable in the upcoming release, it seems like a good idea to port the pipeline script.
Using interchangeable modules for the segmentation step will add a lot of flexibility towards different methods of segmentation (both ML based or color-based) and also trait extraction (think root phenotyping)

- [x] port main.nf to DSL2 https://github.com/Gregor-Mendel-Institute/aradeepopsis/pull/47/commits/0c0a7971902b56d21402d828502540e34c5fde5f
- [x]  factor out processes into individual modules https://github.com/Gregor-Mendel-Institute/aradeepopsis/pull/47/commits/156b3626349ffbea74bf7df063e4816a9ae561f0

This is a PoC implementation that still has some issues. E.g process selectors don't work currently

