### PR TITLE
Bugfix: Explicitly load build-env 2020 for anaconda3

### DIFF
--- a/conf/cbe.config
+++ b/conf/cbe.config
@@ -25,7 +25,7 @@ singularity.cacheDir = '/resources/containers'
 
 process {
   executor = 'slurm'
-  module = 'anaconda3/2019.10'
+  module = 'build-env/2020:anaconda3/2019.10'
   queue = 'c'
   clusterOptions = { task.time <= 1.h ? '--qos rapid' : task.time <= 8.h ? '--qos short': task.time <= 48.h ? '--qos medium' : '--qos long' }
 


### PR DESCRIPTION
This fixes our reframe test as the minimum nextflow requirement for the pipeline is 22.04.x  which is installed in the f2021 build-env